### PR TITLE
Always sync topomap figures to selected dipole oritentation & location; add global "Ready" indicator

### DIFF
--- a/dipole_sim/app.py
+++ b/dipole_sim/app.py
@@ -186,12 +186,14 @@ class App:
         elif state['mode'] == 'set_dipole_pos':
             handle_click_in_set_dipole_pos_mode(widget, state, x_idx, y_idx,
                                                 remaining_idx, x, y,
-                                                self._ras_to_head_t)
+                                                self._ras_to_head_t,
+                                                evoked=self._evoked)
         elif state['mode'] == 'set_dipole_ori':
             # Construct the 3D coordinates of the clicked-on point
             handle_click_in_set_dipole_ori_mode(widget, state, x_idx, y_idx,
                                                 remaining_idx, x, y,
-                                                self._ras_to_head_t)
+                                                self._ras_to_head_t,
+                                                evoked=self._evoked)
 
         self._plot_dipole_markers_and_arrow()
         self._enable_crosshair_cursor()

--- a/dipole_sim/callbacks.py
+++ b/dipole_sim/callbacks.py
@@ -119,11 +119,12 @@ def handle_click_in_slice_browser_mode(widget, markers, state, x, y, x_idx,
     plot_slice(widget, state, y_idx, y, t1_img)
 
     enable_crosshair_cursor(widget)
-    reset_topomaps(widget, evoked)
+    reset_topomaps(widget=widget, evoked=evoked)
 
 
 def handle_click_in_set_dipole_pos_mode(widget, state, x_idx, y_idx,
-                                        remaining_idx, x, y, ras_to_head_t):
+                                        remaining_idx, x, y, ras_to_head_t,
+                                        evoked):
     # for axis in state['dipole_pos'].keys():
     #     state['dipole_pos'][axis] = state['slice_coord'][axis]['val']
 
@@ -149,12 +150,13 @@ def handle_click_in_set_dipole_pos_mode(widget, state, x_idx, y_idx,
                   f"y={round(dipole_pos_head['y'], 3)}, "
                   f"z={round(dipole_pos_head['z'], 3)} [m, MNE Head]")
     widget['label']['dipole_pos'].value = label_text
-
+    reset_topomaps(widget=widget, evoked=evoked)
     leave_set_dipole_pos_mode()
 
 
 def handle_click_in_set_dipole_ori_mode(widget, state, x_idx, y_idx,
-                                        remaining_idx, x, y, ras_to_head_t):
+                                        remaining_idx, x, y, ras_to_head_t,
+                                        evoked):
     dipole_ori_ras = dict()
     dipole_ori_ras[x_idx] = x
     dipole_ori_ras[y_idx] = y
@@ -177,3 +179,5 @@ def handle_click_in_set_dipole_ori_mode(widget, state, x_idx, y_idx,
                   f"y={round(dipole_ori_head['y'], 3)}, "
                   f"z={round(dipole_ori_head['z'], 3)} [m, MNE Head]")
     widget['label']['dipole_ori'].value = label_text
+    reset_topomaps(widget=widget, evoked=evoked)
+    leave_set_dipole_ori_mode()

--- a/dipole_sim/evoked_field.py
+++ b/dipole_sim/evoked_field.py
@@ -39,21 +39,6 @@ def plot_evoked(widget, state, fwd_path, subject, info, ras_to_head_t,
     if fwd_lookup_table is None:
         raise ValueError('Must prodive fwd_lookup_table')
 
-    old_topomap_mag_label_text = state['label_text']['topomap_mag']
-    new_topomap_mag_label_text = old_topomap_mag_label_text + ' [updating]'
-    state['label_text']['topomap_mag'] = new_topomap_mag_label_text
-
-    old_topomap_grad_label_text = state['label_text']['topomap_grad']
-    new_topomap_grad_label_text = old_topomap_grad_label_text + ' [updating]'
-    state['label_text']['topomap_grad'] = new_topomap_grad_label_text
-
-    old_topomap_eeg_label_text = state['label_text']['topomap_eeg']
-    new_topomap_eeg_label_text = old_topomap_eeg_label_text + ' [updating]'
-    state['label_text']['topomap_eeg'] = new_topomap_eeg_label_text
-
-    for ch_type in ['mag', 'grad', 'eeg']:
-        _update_topomap_label(widget, state, ch_type)
-
     dipole_pos = (state['dipole_pos']['x'],
                   state['dipole_pos']['y'],
                   state['dipole_pos']['z'])
@@ -172,13 +157,6 @@ def plot_evoked(widget, state, fwd_path, subject, info, ras_to_head_t,
 
         cb.set_label(label, fontweight='bold')
         fig.canvas.draw()
-
-    state['label_text']['topomap_mag'] = old_topomap_mag_label_text
-    state['label_text']['topomap_grad'] = old_topomap_grad_label_text
-    state['label_text']['topomap_eeg'] = old_topomap_eeg_label_text
-
-    for ch_type in ['mag', 'grad', 'eeg']:
-        _update_topomap_label(widget, state, ch_type)
 
 
 def create_topomap_fig():

--- a/dipole_sim/evoked_field.py
+++ b/dipole_sim/evoked_field.py
@@ -127,9 +127,6 @@ def plot_evoked(widget, state, fwd_path, subject, info, ras_to_head_t,
         ax_topomap = fig.axes[0]
         ax_colorbar = fig.axes[1]
 
-        ax_topomap.clear()
-        ax_colorbar.clear()
-
         if ch_type == 'eeg':
             outlines = 'head'
         else:

--- a/dipole_sim/slice.py
+++ b/dipole_sim/slice.py
@@ -7,11 +7,6 @@ from forward import _create_format_coord
 
 
 def plot_slice(widget, state, axis, pos, t1_img):
-    old_label_text = state['label_text'][axis]
-    new_label_text = old_label_text + ' [updating]'
-    state['label_text'][axis] = new_label_text
-    _update_axis_label(widget, state, axis)
-
     fig = widget['fig'][axis]
 
     with warnings.catch_warnings():  # Suppress DeprecationWarning
@@ -22,8 +17,6 @@ def plot_slice(widget, state, axis, pos, t1_img):
     img.axes[pos].ax.format_coord = _create_format_coord(axis)
     draw_crosshairs(widget=widget, state=state)
     fig.canvas.draw()
-    state['label_text'][axis] = old_label_text
-    _update_axis_label(widget, state, axis)
 
 
 def create_slice_fig(handle_click, handle_enter, handle_leave):


### PR DESCRIPTION
- Add global "Updating / Ready" indicator
- Clear topomaps when dipole positon or orientation have changed
This also ensures that topomaps will be empty if a dipole was placed outside the head and we
cannot calculate the forward projection. Previously, the topomaps evoked by a previous dipole
(which was placed inside the brain) was shown.
